### PR TITLE
Add retry on too many requests

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -485,11 +485,12 @@ func (cli *HTTPClient) retryRequest(
 		}
 
 		// we retry requests if an error is returned from net/http, or if
-		// the status of the response is 502, 503 or 504, which are all proxy
+		// the status of the response is 502, 503, 429 or 504, which are all proxy
 		// errors that may be temporary
 		if err == nil &&
 			res.StatusCode != http.StatusBadGateway &&
 			res.StatusCode != http.StatusServiceUnavailable &&
+			res.StatusCode != http.StatusTooManyRequests &&
 			res.StatusCode != http.StatusGatewayTimeout {
 			break
 		}


### PR DESCRIPTION
There is cases when you get turtling from the API endpoint you sending request
In this case we will retry base on the backoff retry limit