### PR TITLE
options to set a custom HTTP client for the underlaying net layer

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -432,6 +432,12 @@ func (req *HTTPRequest) BodyHandler(handler BodyHandlerFunc) *HTTPRequest {
 	return req
 }
 
+// CustomHTTPClient sets a custom HTTP client for the underlaying net layer
+func (cli *HTTPClient) CustomHTTPClient(cl *http.Client) *HTTPClient {
+	cli.httpCli = cl
+	return cli
+}
+
 func (req *HTTPRequest) Run() error {
 	return req.RunContext(context.Background())
 }


### PR DESCRIPTION
I need to patch v0.2.0 which is the current version we are using, because apparently the new version v1.3.0 causing some regression.